### PR TITLE
Add smart settings merge to installer

### DIFF
--- a/hooks/package.json
+++ b/hooks/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "description": "Hook scripts for Claude Code - safety, formatting, and skill activation",
   "private": true,
-  "type": "module",
   "scripts": {
     "check": "tsc --noEmit",
     "test": "echo 'Run: echo {\"prompt\": \"test\"} | npx tsx skill-activation-prompt.ts'"

--- a/hooks/tsconfig.json
+++ b/hooks/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
+    "module": "CommonJS",
+    "moduleResolution": "node",
     "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary

- The installer now intelligently merges new hooks with your existing configuration
- No more choosing between manual editing or losing your current setup
- Preserves all your custom settings (environment variables, model preferences, status line) while adding new hooks alongside existing ones

## What changed

**Before:** Users with existing `settings.json` had to either manually merge the hooks config or backup and replace everything.

**After:** A new "Auto-merge" option (now the recommended default) uses Node.js to smartly combine configurations:
- Keeps all existing settings untouched
- Adds new hook events that don't exist yet
- Merges hooks into existing events without duplicating
- Creates a backup before making changes
- Falls back gracefully if merge fails

## Test plan

- [ ] Run installer on a fresh system (no existing settings.json)
- [ ] Run installer with existing settings.json and choose option 1 (auto-merge)
- [ ] Verify existing settings are preserved after merge
- [ ] Verify new hooks are added correctly
- [ ] Run installer again to confirm duplicate hooks aren't added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Platform-specific settings template selection for Windows.
  * Three-option settings setup: auto-merge with rollback, backup & fresh install, or skip to manual setup.

* **Improvements**
  * Smarter settings merge with automatic hook deduplication and safer update flow.
  * Updated messaging: PreToolUse = “Safety validation + security warnings”; PostToolUse = “Change tracking + auto-formatting”.
  * Improved tooling compatibility for hooks and install flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->